### PR TITLE
Fixing shell check lint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,7 +16,7 @@
 
 yell() { echo "$0: $*" >&2; }
 die() { yell "$*"; exit 111; }
-try() { echo "$ $@" 1>&2; "$@" || die "cannot $*"; }
+try() { echo "$ $*" 1>&2; "$@" || die "cannot $*"; }
 
 declare -a _stringToArgs
 function stringToArgsArray() {
@@ -24,23 +24,25 @@ function stringToArgsArray() {
 }
 
 setup_autoregister_properties_file_for_elastic_agent() {
-  echo "agent.auto.register.key=${GO_EA_AUTO_REGISTER_KEY}" >> $1
-  echo "agent.auto.register.environments=${GO_EA_AUTO_REGISTER_ENVIRONMENT}" >> $1
-  echo "agent.auto.register.elasticAgent.agentId=${GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID}" >> $1
-  echo "agent.auto.register.elasticAgent.pluginId=${GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID}" >> $1
-  echo "agent.auto.register.hostname=${AGENT_AUTO_REGISTER_HOSTNAME}" >> $1
-
+ {
+    echo "agent.auto.register.key=${GO_EA_AUTO_REGISTER_KEY}"
+    echo "agent.auto.register.environments=${GO_EA_AUTO_REGISTER_ENVIRONMENT}"
+    echo "agent.auto.register.elasticAgent.agentId=${GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID}"
+    echo "agent.auto.register.elasticAgent.pluginId=${GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID}"
+    echo "agent.auto.register.hostname=${AGENT_AUTO_REGISTER_HOSTNAME}"
+  } >> "$1"
   export GO_SERVER_URL="${GO_EA_SERVER_URL}"
   # unset variables, so we don't pollute and leak sensitive stuff to the agent process...
   unset GO_EA_AUTO_REGISTER_KEY GO_EA_AUTO_REGISTER_ENVIRONMENT GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID GO_EA_SERVER_URL AGENT_AUTO_REGISTER_HOSTNAME
 }
 
 setup_autoregister_properties_file_for_normal_agent() {
-  echo "agent.auto.register.key=${AGENT_AUTO_REGISTER_KEY}" >> $1
-  echo "agent.auto.register.resources=${AGENT_AUTO_REGISTER_RESOURCES}" >> $1
-  echo "agent.auto.register.environments=${AGENT_AUTO_REGISTER_ENVIRONMENTS}" >> $1
-  echo "agent.auto.register.hostname=${AGENT_AUTO_REGISTER_HOSTNAME}" >> $1
-
+  {
+    echo "agent.auto.register.key=${AGENT_AUTO_REGISTER_KEY}"
+    echo "agent.auto.register.resources=${AGENT_AUTO_REGISTER_RESOURCES}"
+    echo "agent.auto.register.environments=${AGENT_AUTO_REGISTER_ENVIRONMENTS}"
+    echo "agent.auto.register.hostname=${AGENT_AUTO_REGISTER_HOSTNAME}"
+  } >> "$1"
   # unset variables, so we don't pollute and leak sensitive stuff to the agent process...
   unset AGENT_AUTO_REGISTER_KEY AGENT_AUTO_REGISTER_RESOURCES AGENT_AUTO_REGISTER_ENVIRONMENTS AGENT_AUTO_REGISTER_HOSTNAME
 }
@@ -138,7 +140,7 @@ if [ "$1" = "${AGENT_WORK_DIR}/bin/go-agent" ]; then
   AGENT_BOOTSTRAPPER_JVM_ARGS+=("-Dgo.console.stdout=true")
   for array_index in "${!AGENT_BOOTSTRAPPER_JVM_ARGS[@]}"
   do
-    tanuki_index=$(($array_index + 100))
+    tanuki_index=$((array_index + 100))
     echo "wrapper.java.additional.${tanuki_index}=${AGENT_BOOTSTRAPPER_JVM_ARGS[$array_index]}" >> /go-agent/wrapper-config/wrapper-properties.conf
   done
 
@@ -148,7 +150,7 @@ if [ "$1" = "${AGENT_WORK_DIR}/bin/go-agent" ]; then
 
   for array_index in "${!AGENT_BOOTSTRAPPER_ARGS[@]}"
   do
-    tanuki_index=$(($array_index + 200))
+    tanuki_index=$((array_index + 200))
     echo "wrapper.app.parameter.${tanuki_index}=${AGENT_BOOTSTRAPPER_ARGS[$array_index]}" >> /go-agent/wrapper-config/wrapper-properties.conf
   done
 


### PR DESCRIPTION
Shelllint check error
```$ shellcheck docker-entrypoint.sh

In docker-entrypoint.sh line 19:
try() { echo "$ $@" 1>&2; "$@" || die "cannot $*"; }
                ^-- SC2145: Argument mixes string and array. Use * or separate argument.


In docker-entrypoint.sh line 27:
  echo "agent.auto.register.key=${GO_EA_AUTO_REGISTER_KEY}" >> $1
  ^-- SC2129: Consider using { cmd1; cmd2; } >> file instead of individual redirects.
                                                               ^-- SC2086: Double quote to prevent globbing and word splitting.


In docker-entrypoint.sh line 28:
  echo "agent.auto.register.environments=${GO_EA_AUTO_REGISTER_ENVIRONMENT}" >> $1
                                                                                ^-- SC2086: Double quote to prevent globbing and word splitting.


In docker-entrypoint.sh line 29:
  echo "agent.auto.register.elasticAgent.agentId=${GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID}" >> $1
                                                                                             ^-- SC2086: Double quote to prevent globbing and word splitting.


In docker-entrypoint.sh line 30:
  echo "agent.auto.register.elasticAgent.pluginId=${GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID}" >> $1
                                                                                               ^-- SC2086: Double quote to prevent globbing and word splitting.


In docker-entrypoint.sh line 31:
  echo "agent.auto.register.hostname=${AGENT_AUTO_REGISTER_HOSTNAME}" >> $1
                                                                         ^-- SC2086: Double quote to prevent globbing and word splitting.


In docker-entrypoint.sh line 39:
  echo "agent.auto.register.key=${AGENT_AUTO_REGISTER_KEY}" >> $1
  ^-- SC2129: Consider using { cmd1; cmd2; } >> file instead of individual redirects.
                                                               ^-- SC2086: Double quote to prevent globbing and word splitting.


In docker-entrypoint.sh line 40:
  echo "agent.auto.register.resources=${AGENT_AUTO_REGISTER_RESOURCES}" >> $1
                                                                           ^-- SC2086: Double quote to prevent globbing and word splitting.


In docker-entrypoint.sh line 41:
  echo "agent.auto.register.environments=${AGENT_AUTO_REGISTER_ENVIRONMENTS}" >> $1
                                                                                 ^-- SC2086: Double quote to prevent globbing and word splitting.


In docker-entrypoint.sh line 42:
  echo "agent.auto.register.hostname=${AGENT_AUTO_REGISTER_HOSTNAME}" >> $1
                                                                         ^-- SC2086: Double quote to prevent globbing and word splitting.


In docker-entrypoint.sh line 141:
    tanuki_index=$(($array_index + 100))
                    ^-- SC2004: $/${} is unnecessary on arithmetic variables.


In docker-entrypoint.sh line 151:
    tanuki_index=$(($array_index + 200))
                    ^-- SC2004: $/${} is unnecessary on arithmetic variables.
```
This fixes it

```$ shellcheck docker-entrypoint.sh
$